### PR TITLE
fix webui: use npm token to login

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -283,7 +283,7 @@ export default class OidcPlugin
           );
           await this.redis.expire(`login:${loginRequestId}`, 60 * 60);
 
-          res.set('Content-Type', 'text/html').end(callbackResponseHtml);
+          res.set('Content-Type', 'text/html').end(callbackResponseHtml(npmToken));
         })
         .catch(next);
     });
@@ -317,12 +317,15 @@ export default class OidcPlugin
   }
 }
 
-const callbackResponseHtml = `
+const callbackResponseHtml = (token: string)=>`
 <!DOCTYPE html>
 <html>
   <head>
   </head>
   <body>
+    <script>
+      localStorage.setItem('token', ${JSON.stringify(token)});
+    </script>
     You may close this page now.
     <script>setTimeout(function() {window.close()}, 0)</script>
   </body>


### PR DESCRIPTION
after `npm login` user can now use web ui in same browser where callback handled