### PR TITLE
Implemented access token based authentication (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ auth:
     scope: openid profile email offline_access
     # Optional id_token claim that will be used for username
     usernameClaim: preferred_username
+    # Optional switch to alternative login method, using access token as password.
+    # The username must be the same as the one used to acquire the access token,
+    # the password must be an OIDC access token. The e-mail address will
+    # be ignored.
+    # If not set, the regular authentication flow will be used.
+    accessTokenAuth: false
 ```
 
 OpenID Connect Client must be configured to allow `${publicUrl}/oidc/callback`

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,10 @@ import {
 import {Issuer, Client, TokenSet} from 'openid-client';
 import asyncRetry = require('async-retry');
 import * as express from 'express';
-import {Express} from 'express';
+import {
+  Express, 
+  Response
+} from 'express';
 import {nanoid} from 'nanoid/async';
 import ms = require('ms');
 import * as jwt from 'jsonwebtoken';
@@ -34,6 +37,13 @@ type OidcPluginConfig = {
   redisUri?: string;
   fsSessionStorePath?: string;
   fsTokenStorePath?: string;
+  
+  accessTokenAuth?: boolean;
+};
+
+type Tokens = {
+  npmToken: string;
+  webToken: string;
 };
 
 type RemoteUserEx = RemoteUser & {sid: string};
@@ -395,26 +405,72 @@ export default class OidcPlugin
     app: Express,
     auth: IBasicAuth<OidcPluginConfig>,
   ): void {
-    app.post('/-/v1/login', express.json(), (req, res, next) => {
-      Promise.resolve()
-        .then(async () => {
-          const loginRequestId = await nanoid();
 
-          res.set('Content-Type', 'application/json').end(
-            JSON.stringify({
-              loginUrl: new URL(
-                `oidc/login/${loginRequestId}`,
-                this.options.config.publicUrl,
-              ),
-              doneUrl: new URL(
-                `oidc/done/${loginRequestId}`,
-                this.options.config.publicUrl,
-              ),
-            }),
-          );
-        })
-        .catch(next);
+    app.put('/-/user/org.couchdb.user::userId', express.json(), (req, res, next) => {
+        Promise.resolve()
+          .then(async () => {
+            const subjectToken = req.body.password;
+            if(!subjectToken) {
+              this.unauthorized(res, 'Password attribute is missing.');
+              return;
+            }
+            const userName = req.body.name;
+            if(userName !== req.params.userId) {
+              this.unauthorized(res, 'User ID in URL and body do not match.');
+              return;
+            }
+            const clientSecret = this.options.config.clientSecret;
+            const clientId = this.options.config.clientId;
+            const client = await this.clientPromise;
+            let tokenSet = await client.grant({
+                   "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange", 
+                   "requested_token_type ":"urn:ietf:params:oauth:token-type:refresh_token", 
+                   "client_secret": clientSecret, 
+                   "client_id": clientId,
+                   "subject_token": subjectToken,
+                   "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                   "scope": this.options.config.scope
+            });
+
+            const tokenUsername = this.getUsername(tokenSet);
+            if(userName !== tokenUsername) {
+              this.unauthorized(res, 'Access token is not issued for the user trying to log in.');
+              return;
+            }
+
+            const sessionId = await nanoid();
+            const {npmToken} = await this.saveSessionAndCreateTokens(sessionId, tokenSet, auth);
+            const responseBody = JSON.stringify({"token" : npmToken});
+            res.status(201);
+            res
+              .set('Content-Type', 'application/json')
+              .end(responseBody);
+          })
+          .catch(next);
     });
+
+    if(this.options.config.accessTokenAuth !== true) {
+        app.post('/-/v1/login', express.json(), (req, res, next) => {
+          Promise.resolve()
+            .then(async () => {
+              const loginRequestId = await nanoid();
+
+              res.set('Content-Type', 'application/json').end(
+                JSON.stringify({
+                  loginUrl: new URL(
+                    `oidc/login/${loginRequestId}`,
+                    this.options.config.publicUrl,
+                  ),
+                  doneUrl: new URL(
+                    `oidc/done/${loginRequestId}`,
+                    this.options.config.publicUrl,
+                  ),
+                }),
+              );
+            })
+            .catch(next);
+        });
+    }
 
     app.get('/oidc/login/:loginRequestId', (req, res, next) => {
       Promise.resolve()
@@ -454,41 +510,7 @@ export default class OidcPlugin
           const loginRequestId = params.state;
           const sessionId = await nanoid();
 
-          await this.saveSession(sessionId, tokenSet);
-
-          const username = this.getUsername(tokenSet);
-          const userroles = this.getRoles(tokenSet);
-
-          let npmToken: string;
-          let webToken: string;
-          switch (this.mode) {
-            case PluginMode.LEGACY:
-              npmToken = auth
-                .aesEncrypt(Buffer.from(`${username}:${sessionId}`, 'utf8'))
-                .toString('base64');
-              webToken = npmToken;
-              break;
-            case PluginMode.JWT:
-              const rUser = {
-                ...createRemoteUser(username, userroles),
-                sid: sessionId,
-              };
-
-              npmToken = await signPayload(rUser, auth.config.secret, {
-                expiresIn:
-                  this.options.config.security?.api?.jwt?.sign?.expiresIn,
-              });
-
-              webToken = await signPayload(rUser, auth.config.secret, {
-                // default expiration for web tokens is 7 days:
-                // https://github.com/verdaccio/verdaccio/blob/64f0921477ef68fc96a2327c7a3c86a45f6d0255/packages/config/src/security.ts#L5-L11
-                expiresIn:
-                  this.options.config.security?.web?.sign?.expiresIn ?? '7d',
-              });
-              break;
-            default:
-              throw UnsupportedPluginModeError();
-          }
+          const {npmToken, webToken} = await this.saveSessionAndCreateTokens(sessionId, tokenSet, auth);
 
           await this.ts.set(`login:${loginRequestId}`, npmToken, 5 * 60);
 
@@ -518,6 +540,49 @@ export default class OidcPlugin
         })
         .catch(next);
     });
+  }
+
+  private unauthorized(res: Response, msg: string) : void {
+    this.logger.trace({msg},'Unauthorized access: @{msg}');
+    res.status(401);
+    res
+      .set('Content-Type', 'text/plain')
+      .end(msg);
+  }
+
+  private async saveSessionAndCreateTokens(sessionId: string, tokenSet: TokenSet, auth: IBasicAuth<OidcPluginConfig>): Promise<Tokens> {
+    await this.saveSession(sessionId, tokenSet);
+    const username = this.getUsername(tokenSet);
+    const userroles = this.getRoles(tokenSet);
+    let npmToken: string;
+    let webToken: string;
+    switch (this.mode) {
+      case PluginMode.LEGACY:
+        npmToken = auth
+          .aesEncrypt(Buffer.from(`${username}:${sessionId}`, 'utf8'))
+          .toString('base64');
+        webToken = npmToken;
+        break;
+      case PluginMode.JWT:
+        const rUser = {
+          ...createRemoteUser(username, userroles),
+          sid: sessionId,
+        };
+        npmToken = await signPayload(rUser, auth.config.secret, {
+          expiresIn:
+            this.options.config.security?.api?.jwt?.sign?.expiresIn,
+        });
+        webToken = await signPayload(rUser, auth.config.secret, {
+          // default expiration for web tokens is 7 days:
+          // https://github.com/verdaccio/verdaccio/blob/64f0921477ef68fc96a2327c7a3c86a45f6d0255/packages/config/src/security.ts#L5-L11
+          expiresIn:
+            this.options.config.security?.web?.sign?.expiresIn ?? '7d',
+        });
+        break;
+      default:
+        throw UnsupportedPluginModeError();
+    }
+    return {npmToken, webToken};
   }
 }
 


### PR DESCRIPTION
Added configuration option `accessTokenAuth` which if set to `true`
enables authentication via "regular" npm login. Therefore the password
has to be a base64 encoded access token. The OIDC server must support
the token exchange operation.